### PR TITLE
fix: use the new onTokenTransfer interface for callhooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn build
       - run: yarn test:coverage
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.json

--- a/contracts/BillingConnector.sol
+++ b/contracts/BillingConnector.sol
@@ -216,8 +216,7 @@ contract BillingConnector is IBillingConnector, Governed, Rescuable, L1ArbitrumM
     ) internal {
         require(graphToken.transferFrom(_owner, address(this), _amount), "Add transfer failed");
 
-        bytes memory extraData = abi.encodeWithSelector(IBilling.addFromL1.selector, _to, _amount);
-
+        bytes memory extraData = abi.encode(_to);
         bytes memory data = abi.encode(_maxSubmissionCost, extraData);
 
         graphToken.approve(address(l1TokenGateway), _amount);

--- a/contracts/IBilling.sol
+++ b/contracts/IBilling.sol
@@ -36,12 +36,17 @@ interface IBilling {
     function addTo(address _to, uint256 _amount) external;
 
     /**
-     * @dev Add tokens into the billing contract for any user, from L1
-     * This can only be called from L2GraphTokenGateway.finalizeInboundTransfer.
-     * @param _user  Address that tokens are being added to
-     * @param _amount  Amount of tokens to add
+     * @dev Receive tokens with a callhook from the Arbitrum GRT bridge
+     * Expects an `address user` in the encoded _data.
+     * @param _from Token sender in L1
+     * @param _amount Amount of tokens that were transferred
+     * @param _data ABI-encoded callhook data: contains address that tokens are being added to
      */
-    function addFromL1(address _user, uint256 _amount) external;
+    function onTokenTransfer(
+        address _from,
+        uint256 _amount,
+        bytes calldata _data
+    ) external;
 
     /**
      * @dev Remove tokens from the billing contract, from L1

--- a/test/billingConnector.test.ts
+++ b/test/billingConnector.test.ts
@@ -211,7 +211,7 @@ describe('BillingConnector', () => {
         .addToL2(user2.address, oneHundred, defaultMaxGas, defaultGasPriceBid, defaultMaxSubmissionPrice, {
           value: defaultMsgValue,
         })
-      const expectedCallhookData = billingInterface.encodeFunctionData('addFromL1', [user2.address, oneHundred])
+      const expectedCallhookData = defaultAbiCoder.encode(['address'], [user2.address])
       const expectedOutboundCalldata = l1TokenGatewayMock.interface.encodeFunctionData('finalizeInboundTransfer', [
         token.address,
         billingConnector.address,
@@ -311,7 +311,7 @@ describe('BillingConnector', () => {
             value: defaultMsgValue,
           },
         )
-      const expectedCallhookData = billingInterface.encodeFunctionData('addFromL1', [me.address, oneHundred])
+      const expectedCallhookData = defaultAbiCoder.encode(['address'], [me.address])
       const expectedOutboundCalldata = l1TokenGatewayMock.interface.encodeFunctionData('finalizeInboundTransfer', [
         token.address,
         billingConnector.address,


### PR DESCRIPTION
See https://github.com/graphprotocol/contracts/pull/719